### PR TITLE
Improve snek debugging by providing information on which pattern matched

### DIFF
--- a/app/controllers/sneks_controller.rb
+++ b/app/controllers/sneks_controller.rb
@@ -97,9 +97,9 @@ class SneksController < ApplicationController
     snek_position = snek_positions.select { |sp| sp.snek.id == snek.id }.first
 
     # Check move position
-    move_direction = snek_position.get_next_move(current_arena)
+    (move_direction, pattern_index) = snek_position.get_next_move(current_arena)
 
-    render json: {direction: move_direction}
+    render json: {direction: move_direction, pattern: pattern_index}
   end
 
 end

--- a/app/models/battle.rb
+++ b/app/models/battle.rb
@@ -119,7 +119,7 @@ class Battle < ApplicationRecord
         # Get possible direction for the snek
         # Try to catch https://rollbar.com/noff/snek/items/30/
         begin
-          move_direction = snek_position.get_next_move(current_arena)
+          (move_direction, pattern_index) = snek_position.get_next_move(current_arena)
         rescue NoMethodError => e
           Rollbar.error e,
                         snek_positions: snek_positions,

--- a/app/services/snek_math/position.rb
+++ b/app/services/snek_math/position.rb
@@ -15,7 +15,7 @@ module SnekMath
 
     # Get next possible move direction (N, E, S, W)
     # @param arena [SnekMath::Matrix]
-    # @return String
+    # @return Array
     def get_next_move(arena)
 
       Rails.logger.debug "get_next_move: Snek #{@snek.id}"
@@ -151,7 +151,7 @@ module SnekMath
             # If pattern matched, return it
             if optional_matches.empty? || optional_matches.values.uniq == [true]
               Rails.logger.info "get_next_move: Matched pattern ##{pattern_index} of snek #{@snek.id} to direction #{test_direction}"
-              return test_direction
+              return [test_direction, pattern_index]
             end
 
           end
@@ -161,7 +161,7 @@ module SnekMath
       end
 
       # No steps found, return random direction
-      possible_directions.sample
+      [possible_directions.sample, nil]
     end
 
 

--- a/app/views/sneks/_test.html.erb
+++ b/app/views/sneks/_test.html.erb
@@ -44,8 +44,13 @@
           <div class="row">
             <div class="col-md-4">
               <div id="test-pattern-container"></div>
-              <div v-bind:class="{ invisible: (selected_snek == null) }"><button class="btn btn-sm btn-primary my-3" v-on:click="runTest">Test pattern</button></div>
-              <div id="test-output" v-bind:class="{invisible: (final_direction == null)}">Calculated direction: {{final_direction}}</div>
+              <div class="btn-group mt-2 mb-2 d-flex">
+                <button id="control-prev" type="button" class="btn btn-sm btn-outline-secondary" v-on:click="prevPattern">⏪</button>
+                <button class="btn btn-sm btn-primary w-100" v-on:click="checkPattern" v-bind:disabled="selected_snek === null" v-bind:class="{ 'btn-primary': (selected_snek !== null) }" >Test</button>
+                <button class="btn btn-sm btn-primary w-100" v-on:click="findPattern" v-bind:disabled="selected_snek === null" v-bind:class="{ 'btn-primary': (selected_snek !== null) }" >Find</button>
+                <button id="control-next" type="button" class="btn btn-sm btn-outline-secondary" v-on:click="nextPattern">⏩</button>
+              </div>
+              <div id="test-output"></div>
             </div>
             <div class="col-md-8">
               <div>


### PR DESCRIPTION
What: Enable pattern selection from the test window, showing the result for the selected pattern, a button to find which pattern has matched. Changed backend to return both the direction and the matched pattern's index. Improved data binding, removed (some) state modification from render functions. 

Why: Previous behavior was inconsistent and confusing. A user selects a pattern to test, but the result is returned for a snake move, not for a pattern. 

Demo: 
![image](https://user-images.githubusercontent.com/616841/44665837-8fea3880-aa1f-11e8-83a0-20867ef45ffa.png)




